### PR TITLE
Implement avatar click to play next video

### DIFF
--- a/src/components/StoriesWrapper.tsx
+++ b/src/components/StoriesWrapper.tsx
@@ -8,12 +8,9 @@ export default function StoriesWrapper() {
   const [isTransitioning, setIsTransitioning] = useState(false);
 
   const handleAvatarClick = () => {
-    setIsTransitioning(true);
-    // Delay maior para dar tempo do vídeo carregar
-    setTimeout(() => {
-      setShowStories(true);
-      setIsTransitioning(false);
-    }, 500);
+    // Abrir imediatamente para preservar o gesto do usuário para autoplay
+    setShowStories(true);
+    setIsTransitioning(false);
   };
 
   const handleStoriesEnd = () => {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,6 +14,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["react", "react-dom"],
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
Refactor HLS video playback to enable immediate autoplay.

This change addresses an issue where the first video would wait for full loading before starting, even with autoplay enabled, by adjusting the HLS initialization flow to trigger playback as soon as the manifest is parsed.

---
<a href="https://cursor.com/background-agent?bcId=bc-29af6eeb-6463-412e-9e92-8c8a227ce7d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29af6eeb-6463-412e-9e92-8c8a227ce7d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

